### PR TITLE
Add axethrow upgrades

### DIFF
--- a/Assets/Prefabs/Cleaver.prefab
+++ b/Assets/Prefabs/Cleaver.prefab
@@ -29,6 +29,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 4.773607, y: -3.9416323, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8135946338607085750}
   m_Father: {fileID: 0}
@@ -45,6 +46,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -154,6 +156,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0.288, y: 0.159, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7148817146823030550}
   m_RootOrder: 0
@@ -170,6 +173,7 @@ TrailRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 0
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -229,8 +233,8 @@ TrailRenderer:
       m_RotationOrder: 4
     colorGradient:
       serializedVersion: 2
-      key0: {r: 0.09740115, g: 0.66970897, b: 0.9056604, a: 0.9411765}
-      key1: {r: 0.9433962, g: 0.32395867, b: 0.8672357, a: 0.8627451}
+      key0: {r: 0.9056604, g: 0.86973304, b: 0.8065504, a: 0.9411765}
+      key1: {r: 0.9137255, g: 0.63224244, b: 0.16862743, a: 0.8627451}
       key2: {r: 0, g: 0, b: 0, a: 0.9411765}
       key3: {r: 0, g: 0, b: 0, a: 0}
       key4: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Scripts/AxeThrow.cs
+++ b/Assets/Scripts/AxeThrow.cs
@@ -11,7 +11,6 @@ public class AxeThrow : MonoBehaviour
     [SerializeField] private float stunDuration;
     [HideInInspector]
     public Collider2D enemyHit;
-    private Vector3 playerPos;
     private bool isRotating;
     private bool canDamage;
     private bool canStun;
@@ -73,9 +72,5 @@ public class AxeThrow : MonoBehaviour
     public void setAxeDamage(float damage)
     {
         this.damage = damage;
-    }
-    public void setPlayerPos(Vector3 pos)
-    {
-        playerPos = pos;
     }
 }

--- a/Assets/Scripts/AxeThrow.cs
+++ b/Assets/Scripts/AxeThrow.cs
@@ -73,4 +73,17 @@ public class AxeThrow : MonoBehaviour
     {
         this.damage = damage;
     }
+
+    public void activateAxe()
+    {
+        setcanDamage(true);
+        setisRotating(true);
+    }
+    public void resetAxe()
+    {
+        setcanStun(false);
+        setisRotating(false);
+        setcanDamage(false);
+        enemyHit = null;
+    }
 }

--- a/Assets/Scripts/LevelUpSystem.cs
+++ b/Assets/Scripts/LevelUpSystem.cs
@@ -58,22 +58,25 @@ public class LevelUpSystem : MonoBehaviour
                 playerAction.setSlashNumber(2);     //enable slash burst
                 break;
             case 3:
-                playerAction.enableOppositeSlash(); //enable slash spawning in the opposite position of the original slash
-                playerAction.enableBombGroundDOT(); //enable bomb to spawn a ground DOT effect after exploding
+                playerAction.increaseAxeSize(1.5f); //Increase size the axe by percentage in decimal form
                 break;
             case 4:
-                playerAction.setSlashNumber(3);   
+                playerAction.enableOppositeSlash(); //enable slash spawning in the opposite position of the original slash
                 break;
             case 5:
-                playerAction.increaseAoeBomb(1.5f); //Increase size AOE of Bomb by percentage in decimal form
+                playerAction.enableBombGroundDOT(); //enable bomb to spawn a ground DOT effect after exploding
                 break;
             case 6:
+                playerAction.setSlashNumber(3);
                 break;
             case 7:
+                playerAction.enableCrossAxes();     //enable additonal axes to be throwned in a cross pattern
                 break;
             case 8:
+                playerAction.increaseAoeBomb(1.8f); //Increase size AOE of Bomb by percentage in decimal form
                 break;
             case 9:
+                playerAction.increaseAxeSize(2.0f);
                 break;
             default:
                 break;

--- a/Assets/Scripts/PlayerAction.cs
+++ b/Assets/Scripts/PlayerAction.cs
@@ -24,11 +24,18 @@ public class PlayerAction : MonoBehaviour
     [SerializeField] private float axeDamage; //axe rotation speed when thrown
     [SerializeField] private float projectileSpeed;
     private GameObject axe;
+    private GameObject CrossAxeRight;
+    private GameObject CrossAxeBack;
+    private GameObject CrossAxeLeft;
+    private float axeSizeMulti = 1f;
     private Vector3 targetPos; //where we want to the axe to reach
+    private Vector3 axeStartPos;
     private bool isThrown;
     private bool canCallBack;
     private bool axeReturn;
     private bool axeTimerStarted;
+    private bool CrossAxes;
+    private bool crossAxeSpawned;
 
     //Bomb Spell related
     [SerializeField] private GameObject bombPrefab;
@@ -43,6 +50,7 @@ public class PlayerAction : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        CrossAxes = false;
         canSlash = true;
         numberOfSlashes = 1;
         canBomb = true;
@@ -88,6 +96,7 @@ public class PlayerAction : MonoBehaviour
             if (!canCallBack)
             {
                 targetPos = new Vector3(Camera.main.ScreenToWorldPoint(Input.mousePosition).x, Camera.main.ScreenToWorldPoint(Input.mousePosition).y, 0); //where mouse is when clicked
+                axeStartPos = attackPoint.transform.position;
                 spawnAxe();
             }
         }
@@ -184,23 +193,62 @@ public class PlayerAction : MonoBehaviour
         attackPoint.transform.rotation = Quaternion.Euler(0, 0, rotZ);
         // Handles axe projectile spawn
         axe = Instantiate(axePrefab, attackPoint.transform.position + new Vector3(difference.x, difference.y, 0).normalized, attackPoint.transform.rotation);
+        axe.transform.localScale = axe.transform.localScale * axeSizeMulti;
         axe.GetComponent<AxeThrow>().setAxeDamage(axeDamage);
+        // Handle cross axe spawns
+        if (CrossAxes)
+        {
+            crossAxeSpawned = true;
+            //Using matrix multiplication to rotate the spawn position
+            CrossAxeRight = Instantiate(axePrefab, attackPoint.transform.position + new Vector3(difference.y, -difference.x, 0).normalized, attackPoint.transform.rotation * Quaternion.Euler(0, 0, -90));
+            CrossAxeRight.transform.localScale = CrossAxeRight.transform.localScale * axeSizeMulti;
+            CrossAxeRight.GetComponent<AxeThrow>().setAxeDamage(axeDamage);
+
+            CrossAxeBack = Instantiate(axePrefab, attackPoint.transform.position - new Vector3(difference.x, difference.y, 0).normalized, attackPoint.transform.rotation * Quaternion.Euler(0, 0, -180));
+            CrossAxeBack.transform.localScale = CrossAxeBack.transform.localScale * axeSizeMulti;
+            CrossAxeBack.GetComponent<AxeThrow>().setAxeDamage(axeDamage);
+
+            CrossAxeLeft = Instantiate(axePrefab, attackPoint.transform.position + new Vector3(-difference.y, difference.x, 0).normalized, attackPoint.transform.rotation * Quaternion.Euler(0, 0, -270));
+            CrossAxeLeft.transform.localScale = CrossAxeLeft.transform.localScale * axeSizeMulti;
+            CrossAxeLeft.GetComponent<AxeThrow>().setAxeDamage(axeDamage);
+
+        }
     }
 
     private void axeThrow()
     {
         // Handle axe movement and booleans
-        axe.GetComponent<AxeThrow>().setcanDamage(true);
-        axe.GetComponent<AxeThrow>().setisRotating(true);
+        axe.GetComponent<AxeThrow>().activateAxe();
         if (!canCallBack) //move towards target if axe has not been thrown
         {
             axe.transform.position = Vector2.MoveTowards(axe.transform.position, targetPos, projectileSpeed * Time.deltaTime);
+            if (crossAxeSpawned) //Handle cross axe upgrade (Movement)
+            {
+                Vector3 difference = targetPos - axeStartPos;
+                CrossAxeRight.GetComponent<AxeThrow>().activateAxe();
+                CrossAxeBack.GetComponent<AxeThrow>().activateAxe();
+                CrossAxeLeft.GetComponent<AxeThrow>().activateAxe();
+                CrossAxeRight.transform.position = Vector2.MoveTowards(CrossAxeRight.transform.position, axeStartPos + new Vector3(difference.y, -difference.x, 0), projectileSpeed * Time.deltaTime);
+                CrossAxeBack.transform.position = Vector2.MoveTowards(CrossAxeBack.transform.position, axeStartPos - new Vector3(difference.x, difference.y, 0), projectileSpeed * Time.deltaTime);
+                CrossAxeLeft.transform.position = Vector2.MoveTowards(CrossAxeLeft.transform.position, axeStartPos + new Vector3(-difference.y, difference.x, 0), projectileSpeed * Time.deltaTime);
+            }
         }
         if(canCallBack && axeReturn)
         {
             axe.transform.position = Vector2.MoveTowards(axe.transform.position, attackPoint.transform.position, projectileSpeed * 4 * Time.deltaTime);
 
+            if (crossAxeSpawned)
+            {
+                CrossAxeRight.GetComponent<AxeThrow>().activateAxe();
+                CrossAxeBack.GetComponent<AxeThrow>().activateAxe();
+                CrossAxeLeft.GetComponent<AxeThrow>().activateAxe();
+                CrossAxeRight.transform.position = Vector2.MoveTowards(CrossAxeRight.transform.position, attackPoint.transform.position, projectileSpeed* 4 * Time.deltaTime);
+                CrossAxeBack.transform.position = Vector2.MoveTowards(CrossAxeBack.transform.position, attackPoint.transform.position, projectileSpeed* 4 * Time.deltaTime);
+                CrossAxeLeft.transform.position = Vector2.MoveTowards(CrossAxeLeft.transform.position, attackPoint.transform.position, projectileSpeed* 4 * Time.deltaTime);
+            }
+            
         }
+        
         // Handle when axe has reach targeted pos, No damage and rotation
         if (Vector2.Distance(axe.transform.position, targetPos) <= 0.01f)
         {
@@ -210,13 +258,32 @@ public class PlayerAction : MonoBehaviour
                 axeTimerStarted = true;
             }
             canCallBack = true;
-            axe.GetComponent<AxeThrow>().setcanStun(false);
-            axe.GetComponent<AxeThrow>().setisRotating(false);
-            axe.GetComponent<AxeThrow>().setcanDamage(false);
-            axe.GetComponent<AxeThrow>().enemyHit = null;
+            axe.GetComponent<AxeThrow>().resetAxe();
+
+            if (crossAxeSpawned)
+            {
+                CrossAxeRight.GetComponent<AxeThrow>().resetAxe();
+                CrossAxeBack.GetComponent<AxeThrow>().resetAxe();
+                CrossAxeLeft.GetComponent<AxeThrow>().resetAxe();
+            }
         }
-        // Handle when axe has reached back to player
-        if (Vector2.Distance(axe.transform.position, attackPoint.transform.position) <= 0.01f)
+        // Handle when axe(axes) has reached back to player
+        if (crossAxeSpawned)
+        {
+            if((Vector2.Distance(axe.transform.position, attackPoint.transform.position) <= 0.01f) && 
+               (Vector2.Distance(CrossAxeRight.transform.position, attackPoint.transform.position) <= 0.01f) &&
+               (Vector2.Distance(CrossAxeBack.transform.position, attackPoint.transform.position) <= 0.01f) && 
+               (Vector2.Distance(CrossAxeLeft.transform.position, attackPoint.transform.position) <= 0.01f))
+            {
+                Destroy(CrossAxeRight);
+                Destroy(CrossAxeBack);
+                Destroy(CrossAxeLeft);
+                Destroy(axe);
+                isThrown = false;
+                canCallBack = false;
+                axeReturn = false;
+            }  
+        }else if(Vector2.Distance(axe.transform.position, attackPoint.transform.position) <= 0.01f)
         {
             isThrown = false;
             canCallBack = false;
@@ -228,7 +295,6 @@ public class PlayerAction : MonoBehaviour
     //handles timer for axe throw return
     private IEnumerator axeReturnTimer()
     {
-        Debug.Log("axeTimer");
         yield return new WaitForSeconds(0.15f);
         axeReturn = true;
     }
@@ -271,5 +337,13 @@ public class PlayerAction : MonoBehaviour
     public void setAxeDamagelvl(float percentageDmgInc)
     {
         axeDamage = Mathf.RoundToInt(axeDamage * percentageDmgInc);
+    }
+    public void enableCrossAxes()
+    {
+        CrossAxes = true;
+    }
+    public void increaseAxeSize(float percentageIncrease)
+    {
+        axeSizeMulti = percentageIncrease;
     }
 }


### PR DESCRIPTION
Changed axe throw to automatically return to the player after it has reached its destination(Timed).

Added two upgrades for the axe throw.

One upgrade enables 4 axes to spawn forming a cross.

The other upgrade increases the axe size.

Updated what upgrades the player unlocks at certain levels.

Updated axe trail colour.